### PR TITLE
Fixed behavior of animate() in non-looping gifs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ hi.show();
 ````
 
 Notice that you need to pass in the length of the input stream that is decoded when opening a gif.
+
+## Changelog
+### 2017-12-25
+#### Modified
+- Loop checking inside animate() function yields sensible results for finite looped gifs.
+- Animate function no longer skips last frame.

--- a/src/com/codename1/gif/GifImage.java
+++ b/src/com/codename1/gif/GifImage.java
@@ -35,9 +35,9 @@ import java.util.ArrayList;
 /**
  * <p>This is a GIF image implementation based on the code from https://gist.github.com/devunwired/4479231
  * To use this just use  {@code Image img = GifImage.decode(inputStream, lengthOfStream); }
- * You can then use the image as any other Codename One image. Looping, timing etc. is determined by 
+ * You can then use the image as any other Codename One image. Looping, timing etc. is determined by
  * the internal loop definitions in the GIF.</p>
- * 
+ *
  * <p>
  * Reads frame data from a GIF image source and decodes it into individual frames
  * for animation purposes.  Image data can be read from either and InputStream source
@@ -159,7 +159,7 @@ public class GifImage extends Image {
     private GifImage() {
         super(null);
     }
-    
+
     /**
      * Move the animation frame counter forward
      */
@@ -804,7 +804,7 @@ public class GifImage extends Image {
             readBlock();
         } while ((blockSize > 0) && !err());
     }
-    
+
     public static GifImage decode(InputStream is, int contentLength) throws IOException {
         final GifImage gifimg = new GifImage();
         int ec = gifimg.read(is, contentLength);
@@ -821,11 +821,11 @@ public class GifImage extends Image {
             gifimg.frameTimes[i] = currentTime;
             currentTime  += gifimg.getDelay(i);
         }
-        
+
         gifimg.duration = currentTime;
         gifimg.actualWidth = gifimg.frameImages[0].getWidth();
         gifimg.actualHeight = gifimg.frameImages[0].getHeight();
-        
+
         return gifimg;
     }
 
@@ -869,30 +869,35 @@ public class GifImage extends Image {
 
     @Override
     public boolean animate() {
-        if(startTime < 0) {
-            startTime = System.currentTimeMillis();
-        }
-        int time = (int)(System.currentTimeMillis() - startTime);
-        if(loopCount > 0) {
-            if(time % duration > loopCount) {
-                return false;
-            }
-        }
-        time %= duration;
-        int newFrame = 0;
-        for(int iter = 0 ; iter < frameTimes.length ; iter++) {
-            if(frameTimes[iter] > time) {
-                newFrame = iter - 1;
-                break;
-            }
-        }
-        if(newFrame != frame) {
-            frame = newFrame;
-            return true;
-        }
-        return false;
+      if(startTime < 0) {
+          startTime = System.currentTimeMillis();
+      }
+
+      int time = (int)(System.currentTimeMillis() - startTime);
+      if(loopCount > 0) {
+          if(time > loopCount*duration) {
+              return false;
+          }
+      }
+
+      time %= duration;
+      int newFrame = 0;
+      for(int iter = 0 ; iter < frameTimes.length ; iter++) {
+          if(frameTimes[iter] > time) {
+              newFrame = iter - 1;
+              break;
+          }
+      }
+      if(time >= frameTimes[frameTimes.length-1])
+        newFrame = frameCount - 1;
+
+      if(newFrame != frame) {
+          frame = newFrame;
+          return true;
+      }
+      return false;
     }
-    
+
     static class ByteBuffer {
         static final int UNSET_MARK = -1;
         final byte[] backingArray;
@@ -903,7 +908,7 @@ public class GifImage extends Image {
         public ByteBuffer(byte[] b) {
             backingArray = b;
         }
-        
+
         public final ByteBuffer rewind() {
             position = 0;
             mark = UNSET_MARK;
@@ -926,11 +931,11 @@ public class GifImage extends Image {
                 mark = UNSET_MARK;
             }
         }
-        
+
         public final byte get() {
           return backingArray[position++];
         }
-        
+
         public final ByteBuffer get(byte[] dst, int dstOffset, int byteCount) {
             System.arraycopy(backingArray, position, dst, dstOffset, byteCount);
             position += byteCount;
@@ -944,7 +949,7 @@ public class GifImage extends Image {
         public final int position() {
             return position;
         }
-        
+
         public final short getShort() {
             int newPosition = position + 2; //SizeOf.SHORT;
             short result = (short) ((backingArray[position + 1] << 8) | (backingArray[position] & 0xff));

--- a/src/com/codename1/gif/GifImage.java
+++ b/src/com/codename1/gif/GifImage.java
@@ -35,9 +35,9 @@ import java.util.ArrayList;
 /**
  * <p>This is a GIF image implementation based on the code from https://gist.github.com/devunwired/4479231
  * To use this just use  {@code Image img = GifImage.decode(inputStream, lengthOfStream); }
- * You can then use the image as any other Codename One image. Looping, timing etc. is determined by 
+ * You can then use the image as any other Codename One image. Looping, timing etc. is determined by
  * the internal loop definitions in the GIF.</p>
- * 
+ *
  * <p>
  * Reads frame data from a GIF image source and decodes it into individual frames
  * for animation purposes.  Image data can be read from either and InputStream source
@@ -159,7 +159,7 @@ public class GifImage extends Image {
     private GifImage() {
         super(null);
     }
-    
+
     /**
      * Move the animation frame counter forward
      */
@@ -804,7 +804,7 @@ public class GifImage extends Image {
             readBlock();
         } while ((blockSize > 0) && !err());
     }
-    
+
     public static GifImage decode(InputStream is, int contentLength) throws IOException {
         final GifImage gifimg = new GifImage();
         int ec = gifimg.read(is, contentLength);
@@ -821,11 +821,11 @@ public class GifImage extends Image {
             gifimg.frameTimes[i] = currentTime;
             currentTime  += gifimg.getDelay(i);
         }
-        
+
         gifimg.duration = currentTime;
         gifimg.actualWidth = gifimg.frameImages[0].getWidth();
         gifimg.actualHeight = gifimg.frameImages[0].getHeight();
-        
+
         return gifimg;
     }
 
@@ -869,30 +869,35 @@ public class GifImage extends Image {
 
     @Override
     public boolean animate() {
-        if(startTime < 0) {
-            startTime = System.currentTimeMillis();
-        }
-        int time = (int)(System.currentTimeMillis() - startTime);
-        if(loopCount > 0) {
-            if(time % duration > loopCount) {
-                return false;
-            }
-        }
-        time %= duration;
-        int newFrame = 0;
-        for(int iter = 0 ; iter < frameTimes.length ; iter++) {
-            if(frameTimes[iter] > time) {
-                newFrame = iter - 1;
-                break;
-            }
-        }
-        if(newFrame != frame) {
-            frame = newFrame;
-            return true;
-        }
-        return false;
+      if(startTime < 0) {
+          startTime = System.currentTimeMillis();
+      }
+
+      int time = (int)(System.currentTimeMillis() - startTime);
+      if(loopCount > 0) {
+          if(time > loopCount*duration) {
+              return false;
+          }
+      }
+
+      time %= duration;
+      int newFrame = 0;
+      for(int iter = 0 ; iter < frameTimes.length ; iter++) {
+          if(frameTimes[iter] > time) {
+              newFrame = iter - 1;
+              break;
+          }
+      }
+      if(time > frameTimes[frameTimes.length-1])
+        newFrame = frameCount - 1;
+
+      if(newFrame != frame) {
+          frame = newFrame;
+          return true;
+      }
+      return false;
     }
-    
+
     static class ByteBuffer {
         static final int UNSET_MARK = -1;
         final byte[] backingArray;
@@ -903,7 +908,7 @@ public class GifImage extends Image {
         public ByteBuffer(byte[] b) {
             backingArray = b;
         }
-        
+
         public final ByteBuffer rewind() {
             position = 0;
             mark = UNSET_MARK;
@@ -926,11 +931,11 @@ public class GifImage extends Image {
                 mark = UNSET_MARK;
             }
         }
-        
+
         public final byte get() {
           return backingArray[position++];
         }
-        
+
         public final ByteBuffer get(byte[] dst, int dstOffset, int byteCount) {
             System.arraycopy(backingArray, position, dst, dstOffset, byteCount);
             position += byteCount;
@@ -944,7 +949,7 @@ public class GifImage extends Image {
         public final int position() {
             return position;
         }
-        
+
         public final short getShort() {
             int newPosition = position + 2; //SizeOf.SHORT;
             short result = (short) ((backingArray[position + 1] << 8) | (backingArray[position] & 0xff));


### PR DESCRIPTION
Hi Shai (and whoever else might be maintaining this),

I was working on a project and I noticed that the GifImage class didn't properly animate for gifs that did not loop infinitely- namely, it simply displayed the first frame indefinitely.

I hope this isn't too obtrusive, but I'd like to commit the changes I made to get it to work properly.

There were two things in the animate() function causing this behavior- firstly- to check if the animate had exceeded the loop time, the condition was
```
if(time%duration > loopCount)
    return false;
```
time%duration for any reasonably animated gif is going to give a few dozen milliseconds at the very least, and it doesn't make sense to compare it to loop count.
I've changed the condition to
```
if(time > loopCount*duration)
    return false;
```

The second thing causing this behavior was the loop to find the new frame number at the time of function call.
The code
```
        for(int iter = 0 ; iter < frameTimes.length ; iter++) {
            if(frameTimes[iter] > time) {
                newFrame = iter - 1;
                break;
            }
        }
```
can at most change newFrame to equal frameCount-2, since it's checking for time at the beginning of the current frame to get to the previous frame, and the last frame is not the previous frame of any other frames.

I've added a condition after the loop
```
        if(time >= frameTimes[frameTimes.length-1])
        	newFrame = frameCount - 1;
```
that accounts for this.

Thank you for all your awesome work on this software. I'm having a lot of fun learning it and using it for my current project.

Cheers!